### PR TITLE
Fix infinite loop in pad_uuid

### DIFF
--- a/lib/shortuuid.ex
+++ b/lib/shortuuid.ex
@@ -242,6 +242,7 @@ defmodule ShortUUID do
   defp pad_shortuuid(shortuuid), do: pad_shortuuid(shortuuid <> <<50>>)
 
   @spec pad_uuid(binary()) :: binary()
+  defp pad_uuid(uuid) when byte_size(uuid) > 32, do: throw(:error)
   defp pad_uuid(<<_::binary-size(32)>> = uuid), do: uuid
   defp pad_uuid(uuid), do: pad_uuid(<<48>> <> uuid)
 

--- a/test/shortuuid_test.exs
+++ b/test/shortuuid_test.exs
@@ -129,6 +129,10 @@ defmodule ShortUUIDTest do
       end
     end
 
+    test "fails when decoded hex value is > 32 bytes" do
+      assert {:error, _} = ShortUUID.decode("vurAvy8qYnp94isZcMSEPp")
+    end
+
     test "fails when encoded value is > 128 bit" do
       assert {:error, _} = ShortUUID.decode("6B8cwPMGnU6qLbRvo7qEZo2")
     end


### PR DESCRIPTION
Guard pad_uuid against decoded hex values that are greater that 32 bytes.

Issue #1