### PR TITLE
Fix endless loop for shortuuids with int values >128bit

### DIFF
--- a/lib/shortuuid.ex
+++ b/lib/shortuuid.ex
@@ -143,7 +143,6 @@ defmodule ShortUUID do
   defp int_to_string(number, acc \\ [])
 
   defp int_to_string(number, acc) when number > 0 do
-    # int_to_string(div(number, 57), [acc | <<e(rem(number, 57))>>])
     int_to_string(div(number, 57), [acc | elem(@alphabet_tuple, rem(number, 57))])
   end
 
@@ -162,6 +161,8 @@ defmodule ShortUUID do
       c(c1), c(c2), c(c3), c(c4), ?-, c(d1), c(d2), c(d3), c(d4), ?-, c(e1), c(e2), c(e3), c(e4),
       c(e5), c(e6), c(e7), c(e8), c(e9), c(e10), c(e11), c(e12)>>
   end
+
+  defp format_uuid(_), do: throw(:error)
 
   @doc """
   Decode a ShortUUID.
@@ -205,7 +206,7 @@ defmodule ShortUUID do
       acc * 57 + index
     end)
     |> Integer.to_string(16)
-    |> pad_uuid
+    |> String.pad_leading(32, <<48>>)
     |> format_uuid
   catch
     :error -> {:error, "Invalid input"}
@@ -240,10 +241,6 @@ defmodule ShortUUID do
   @spec pad_shortuuid(binary()) :: binary()
   defp pad_shortuuid(<<_::176>> = shortuuid), do: shortuuid
   defp pad_shortuuid(shortuuid), do: pad_shortuuid(shortuuid <> <<50>>)
-
-  @spec pad_uuid(binary()) :: binary()
-  defp pad_uuid(<<_::binary-size(32)>> = uuid), do: uuid
-  defp pad_uuid(uuid), do: pad_uuid(<<48>> <> uuid)
 
   @compile {:inline, b: 1}
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule ShortUUID.Mixfile do
   use Mix.Project
 
   @name "ShortUUID"
-  @version "2.1.1"
+  @version "2.1.2"
   @url "https://github.com/gpedic/ex_shortuuid"
 
   def project do

--- a/test/shortuuid_test.exs
+++ b/test/shortuuid_test.exs
@@ -130,7 +130,7 @@ defmodule ShortUUIDTest do
     end
 
     test "fails when encoded value is > 128 bit" do
-      assert {:error, _} = ShortUUID.decode("6B8cwPMGnU6qLbRvo7qEZo2")
+      assert {:error, _} = ShortUUID.decode("6B8cwPMGnU6qLbRvo7qEZo")
     end
 
     test "should still support legacy unpadded strings" do
@@ -152,5 +152,3 @@ defmodule ShortUUIDTest do
     end
   end
 end
-
-


### PR DESCRIPTION
Numbers >128bit will produce a hex string > 32characters which would
trip up the pad_uuid function as there was no end condition except size
being exactly 32

Bump version to v2.1.2

Fixes #1

Thanks to @benkimpel for figuring this one out