### PR TITLE
Support MSB first

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+elixir 1.15.2-otp-25
+erlang 25.3.2.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,42 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## v3.0.0
+* move most significant bit to the begginging of the encoded result
+* drop support for decoding of unpadded ShortUUIDs
+* drop support for formats other than regular hyphenated and unhyphenated UUIDs, MS format and binary UUIDs like are stored in PostgreSQL uuid type
+* refactor code for better readability
+* improve encode and decode performance
+
+### Benchmarks
+Results are not comparable to previous benchmarks due to them being run on a different system
+
+Operating System: macOS
+CPU Information: Apple M2 Max
+Number of Available Cores: 12
+Available memory: 32 GB
+Elixir 1.15.2
+Erlang 25.3.2.3
+
+* v3.0.0
+
+Name                                        ips        average  deviation         median         99th %
+encode/1 binary uuid                  1212.57 K        0.82 μs  ±1995.67%        0.75 μs        1.00 μs
+encode/1 unhyphenated uuid string      788.79 K        1.27 μs   ±984.70%        1.13 μs        1.63 μs
+encode/1 hyphenated uuid string        753.56 K        1.33 μs  ±1106.96%        1.17 μs        1.67 μs
+encode/1 uuid string with braces       722.36 K        1.38 μs  ±1188.51%        1.21 μs        1.83 μs
+decode/1                                 1.15 M      868.43 ns  ±1506.27%         751 ns        1334 ns
+
+* v2.1.1
+
+Name                                        ips        average  deviation         median         99th %
+encode/1 binary uuid                    1018.43 K        0.98 μs  ±1224.91%        0.88 μs        1.25 μs
+encode/1 unhyphenated uuid string        849.67 K        1.18 μs  ±1171.07%        1.08 μs        1.42 μs
+encode/1 hyphenated uuid string          731.91 K        1.37 μs   ±691.40%        1.29 μs        1.63 μs
+encode/1 uuid string with braces         569.16 K        1.76 μs   ±833.41%        1.63 μs        2.17 μs
+decode/1                                   1.00 M      996.37 ns   ±781.87%         918 ns        1376 ns
+
+
 ## v2.1.1 (2019-02-18)
 
 * speed improvements
@@ -51,9 +87,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * drop support for custom alphabets
 * use fixed alphabet _23456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz_ as it seems to be by far the most widely used shortuuid alphabet
-
-## v3.0.0
-* drop support for decoding of unpadded ShortUUIDs
-* drop support for formats other than regular hyphenated and unhyphenated UUIDs, MS format and binary UUIDs like are stored in PostgreSQL uuid type
-* refactor code for better readability
-* improve decode performance

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ ShortUUID supports common UUID formats and is case-insensitive. It also supports
 
 ## Compatibility
 
-Starting with version v3.0.0, this library will follow suit with changes in other language implementations and move the most significant bit of the encoded value to the start. This also means that padding will be applied to the end of the string, not the start
+Starting with version `v3.0.0`, this library will follow suit with changes in other language implementations and move the most significant bit of the encoded value to the start. This also means that padding will be applied to the end of the string, not the start
 This change will restore compatibility with other libraries like [shortuuid](https://github.com/skorokithakis/shortuuid) from v1.0.0 onwards and [short-uuid
 ](https://github.com/oculus42/short-uuid).
 
-Before v3.0.0
+Before `v3.0.0`
 ```elixir
 
 iex> "00000001-0001-0001-0001-000000000001" |> ShortUUID.encode
@@ -35,7 +35,7 @@ iex> "00000001-0001-0001-0001-000000000001" |> ShortUUID.encode
 
 ```
 
-After v3.0.0
+After `v3.0.0`
 ```elixir
 
 iex> "00000001-0001-0001-0001-000000000001" |> ShortUUID.encode
@@ -110,4 +110,6 @@ Inspired by [shortuuid](https://github.com/skorokithakis/shortuuid).
 Copyright (c) 2019 Goran Pedić
 
 This work is free. You can redistribute it and/or modify it under the
-terms of the MIT License. See the [LICENSE.md](./LICENSE.md) file for more details.
+terms of the MIT License. 
+
+See the [LICENSE.md](./LICENSE.md) file for more details.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,48 @@ Unlike some other libraries, ShortUUID doesn't generate UUIDs itself. Instead, y
 
 ShortUUID supports common UUID formats and is case-insensitive. It also supports binary UUIDs returned from DBs like PostgreSQL when the uuid type is used to store the UUID.
 
+## Compatibility
+
+Starting with version v3.0.0, this library will follow suit with changes in other language implementations and move the most significant bit of the encoded value to the start. This also means that padding will be applied to the end of the string, not the start
+This change will restore compatibility with other libraries like [shortuuid](https://github.com/skorokithakis/shortuuid) from v1.0.0 onwards and [short-uuid
+](https://github.com/oculus42/short-uuid).
+
+Before v3.0.0
+```elixir
+
+iex> "00000001-0001-0001-0001-000000000001" |> ShortUUID.encode
+{:ok, "UD6ibhr3V4YXvriP822222"}
+
+```
+
+After v3.0.0
+```elixir
+
+iex> "00000001-0001-0001-0001-000000000001" |> ShortUUID.encode
+{:ok, "222228PirvXY4V3rhbi6DU"}
+
+```
+
+To decode ShortUUID created with version < v3.0.0 use one of two methods
+
+```elixir
+iex> "UD6ibhr3V4YXvriP822222" |> String.reverse() |> ShortUUID.decode()
+{:ok, "00000001-0001-0001-0001-000000000001"}
+
+iex> "UD6ibhr3V4YXvriP822222" |> ShortUUID.decode(legacy: true)
+{:ok, "00000001-0001-0001-0001-000000000001"}
+
+```
+
+Decoding legacy ShortUUIDs without either reversing the string first or using the legacy option will not fail but produce an incorrect result
+
+```elixir
+iex> "UD6ibhr3V4YXvriP822222" |> ShortUUID.decode!() === "00000001-0001-0001-0001-000000000001"
+false
+iex> "UD6ibhr3V4YXvriP822222" |> ShortUUID.decode()
+{:ok, "933997ef-eb92-293f-b202-2a879fc84be9"}
+```
+
 ## Installation
 
 Add `:shortuuid` to your list of dependencies in `mix.exs`:
@@ -37,15 +79,15 @@ end
 
 ```elixir
 iex> "f98e80e7-9923-4173-8408-98f8254912ad" |> ShortUUID.encode
-{:ok, "EwQd7sRtDbyyB6QRSWAtQn"}
+{:ok, "nQtAWSRQ6ByybDtRs7dQwE"}
 
 iex> "f98e80e7-9923-4173-8408-98f8254912ad" |> ShortUUID.encode!
-"EwQd7sRtDbyyB6QRSWAtQn"
+"nQtAWSRQ6ByybDtRs7dQwE"
 
-iex> "EwQd7sRtDbyyB6QRSWAtQn" |> ShortUUID.decode
+iex> "nQtAWSRQ6ByybDtRs7dQwE" |> ShortUUID.decode
 {:ok, "f98e80e7-9923-4173-8408-98f8254912ad"}
 
-iex> "EwQd7sRtDbyyB6QRSWAtQn" |> ShortUUID.decode!
+iex> "nQtAWSRQ6ByybDtRs7dQwE" |> ShortUUID.decode!
 "f98e80e7-9923-4173-8408-98f8254912ad"
 ```
 

--- a/lib/shortuuid.ex
+++ b/lib/shortuuid.ex
@@ -253,8 +253,8 @@ defmodule ShortUUID do
   # Retrieves the index of a given character in the alphabet.
   # This function is generated for each character in the alphabet for quick access.
   @compile {:inline, char_to_index: 1}
-  for {char, i} <- @codepoint_index do
-    defp char_to_index(unquote(char)), do: unquote(i)
+  for {char, index} <- @codepoint_index do
+    defp char_to_index(unquote(char)), do: unquote(index)
   end
 
   defp char_to_index(_), do: raise(ArgumentError)

--- a/lib/shortuuid.ex
+++ b/lib/shortuuid.ex
@@ -16,13 +16,12 @@ defmodule ShortUUID do
 
   The encode/1 function translates UUIDs to base57 using lowercase and uppercase letters, as well as digits,
   while ensuring that similar-looking characters such as 'l', '1', 'I', 'O', and '0' are avoided.
-
         iex> ShortUUID.encode("ed7ba470-8e54-465e-825c-99712043e01c")
-        {:ok, "zpZwXhCTZFcjzuEELvmSGk"}
+        {:ok, "kGSmvLEEuzjcFZTChXwZpz"}
 
   The decode/1 function will turn the ShortUUID back into a regular UUID
 
-        iex> ShortUUID.decode("zpZwXhCTZFcjzuEELvmSGk")
+        iex> ShortUUID.decode("kGSmvLEEuzjcFZTChXwZpz")
         {:ok, "ed7ba470-8e54-465e-825c-99712043e01c"}
 
 
@@ -46,7 +45,7 @@ defmodule ShortUUID do
   Since version v2.1.0, ShortUUID also supports the encoding of binary UUIDs.
 
       iex> ShortUUID.encode!(<<0xFA, 0x62, 0xAF, 0x80, 0xA8, 0x61, 0x45, 0x6C, 0xAB, 0x77, 0xD5, 0x67, 0x7E, 0x2E, 0x8B, 0xA8>>)
-      "PuQURs6h2XSBBVNgqSHJZn"
+      "nZJHSqgNVBBSX2h6sRUQuP"
 
   ## Using ShortUUID with Ecto
 
@@ -57,48 +56,47 @@ defmodule ShortUUID do
     This project was inspired by
     [skorokithakis/shortuuid](https://github.com/skorokithakis/shortuuid).
   """
-  use Bitwise, only_operators: true
+  import Bitwise
   @alphabet "23456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
-  @alphabet_tuple @alphabet |> String.split("", trim: true) |> List.to_tuple()
-  @alphabet_list String.graphemes(@alphabet) |> Enum.with_index()
+  @alphabet_tuple @alphabet |> String.graphemes() |> List.to_tuple()
+  @codepoint_index String.to_charlist(@alphabet) |> Enum.with_index()
 
   @doc """
   Encodes a UUID into a ShortUUID string.
   """
   @spec encode(binary) :: {:ok, String.t()} | {:error, String.t()}
+  def encode(uuid)
+
   def encode(
         <<a::binary-size(8), ?-, b::binary-size(4), ?-, c::binary-size(4), ?-, d::binary-size(4),
           ?-, e::binary-size(12)>>
       ) do
-    decode_uuid(
+    encode_uuid_string(
       <<a::binary-size(8), b::binary-size(4), c::binary-size(4), d::binary-size(4),
         e::binary-size(12)>>
     )
   end
 
   def encode(<<_::binary-size(32)>> = uuid) do
-    decode_uuid(uuid)
+    encode_uuid_string(uuid)
   end
 
   def encode(
         <<?{, a::binary-size(8), ?-, b::binary-size(4), ?-, c::binary-size(4), ?-,
           d::binary-size(4), ?-, e::binary-size(12), ?}>>
       ) do
-    decode_uuid(
+    encode_uuid_string(
       <<a::binary-size(8), b::binary-size(4), c::binary-size(4), d::binary-size(4),
         e::binary-size(12)>>
     )
   end
 
   def encode(<<?{, uuid::binary-size(32), ?}>>) do
-    decode_uuid(<<uuid::binary-size(32)>>)
+    encode_uuid_string(<<uuid::binary-size(32)>>)
   end
 
   def encode(<<int_value::128>> = uuid) when is_binary(uuid) do
-    uuid =
-      int_value
-      |> int_to_string()
-      |> pad_shortuuid()
+    uuid = int_to_string(int_value) |> pad_shortuuid()
 
     {:ok, uuid}
   end
@@ -124,24 +122,75 @@ defmodule ShortUUID do
   @doc """
   Decodes a ShortUUID string into a UUID.
   """
-  @spec decode(String.t()) :: {:ok, String.t()} | {:error, String.t()}
-  def decode(shortuuid)
-      when is_binary(shortuuid) and byte_size(shortuuid) == 22 do
-    with {:ok, int_value} <- shortuuid_string_to_int(shortuuid),
-         0 <- int_value >>> 128 do
-      uuid =
-        <<int_value::128>>
-        |> Base.encode16(case: :lower)
-        |> format_uuid()
+  @spec decode(String.t(), keyword()) :: {:ok, String.t()} | {:error, String.t()}
+  def decode(shortuuid, opts \\ [legacy: false])
 
-      {:ok, uuid}
-    else
+  def decode(
+        <<c1::8, c2::8, c3::8, c4::8, c5::8, c6::8, c7::8, c8::8, c9::8, c10::8, c11::8, c12::8,
+          c13::8, c14::8, c15::8, c16::8, c17::8, c18::8, c19::8, c20::8, c21::8, c22::8>>,
+        legacy: false
+      ) do
+    uuid_int_value =
+      [
+        c1,
+        c2,
+        c3,
+        c4,
+        c5,
+        c6,
+        c7,
+        c8,
+        c9,
+        c10,
+        c11,
+        c12,
+        c13,
+        c14,
+        c15,
+        c16,
+        c17,
+        c18,
+        c19,
+        c20,
+        c21,
+        c22
+      ]
+      |> Enum.reduce(0, fn char, acc ->
+        acc * 57 + char_to_index(char)
+      end)
+
+    # verify our int value is <= 128 bits
+    # shift it right 128 bits, the result must be 0
+    case uuid_int_value >>> 128 do
+      0 ->
+        uuid =
+          <<uuid_int_value::128>>
+          |> Base.encode16(case: :lower)
+          |> format_uuid()
+
+        {:ok, uuid}
+
       _ ->
         {:error, "Invalid input"}
     end
+  rescue
+    _ ->
+      {:error, "Invalid input"}
   end
 
-  def decode(_string) do
+  def decode(
+        <<c1::8, c2::8, c3::8, c4::8, c5::8, c6::8, c7::8, c8::8, c9::8, c10::8, c11::8, c12::8,
+          c13::8, c14::8, c15::8, c16::8, c17::8, c18::8, c19::8, c20::8, c21::8, c22::8>>,
+        legacy: true
+      ) do
+    decode(
+      <<c22, c21, c20, c19, c18, c17, c16, c15, c14, c13, c12, c11, c10, c9, c8, c7, c6, c5, c4,
+        c3, c2, c1>>,
+      legacy: false
+    )
+  end
+
+  def decode(_string, _opts) do
     {:error, "Invalid input"}
   end
 
@@ -150,9 +199,9 @@ defmodule ShortUUID do
 
   Raises an ArgumentError if the ShortUUID is invalid.
   """
-  @spec decode!(String.t()) :: String.t() | no_return()
-  def decode!(string) do
-    case decode(string) do
+  @spec decode!(String.t(), keyword()) :: String.t() | no_return()
+  def decode!(string, opts \\ [legacy: false]) do
+    case decode(string, opts) do
       {:ok, uuid} -> uuid
       {:error, message} -> raise ArgumentError, message: message
     end
@@ -164,11 +213,10 @@ defmodule ShortUUID do
 
   # - `format_uuid/1`: Formats a UUID into a standard string form.
   # - `int_to_string/2`: Converts a given integer to a string, according to the predefined alphabet.
-  # - `shortuuid_string_to_int/1`: Converts a short UUID string back into its integer form.
-  # - `pad_shortuuid/1`: Pads the given short UUID with the first character of the alphabet until its size reaches 22.
+  # - `pad_shortuuid/2`: Pads the given short UUID with the first character of the alphabet until its size reaches 22.
   # - `char_to_index/1`: Retrieves the index of a given character in the alphabet.
 
-  defp decode_uuid(uuid) do
+  defp encode_uuid_string(uuid) do
     uuid
     |> Base.decode16(case: :mixed)
     |> case do
@@ -189,46 +237,25 @@ defmodule ShortUUID do
   end
 
   # Converts a given integer to a string, according to the predefined alphabet.
-  # This function uses tail recursion for efficiency and reverses the resulting list at the end for correctness.
-  defp int_to_string(number, acc \\ "")
+  defp int_to_string(number, acc \\ [])
   defp int_to_string(0, acc), do: acc |> to_string
 
   defp int_to_string(number, acc) when number > 0 do
-    int_to_string(div(number, 57), acc <> elem(@alphabet_tuple, rem(number, 57)))
-  end
-
-  # Converts a short UUID string back into its integer form.
-  # This function uses the `Enum.reduce_while/3` function to halt the process when an invalid character is encountered.
-  defp shortuuid_string_to_int(shortuuid_string) do
-    shortuuid_string
-    |> :binary.bin_to_list()
-    |> :lists.reverse()
-    |> Enum.reduce_while(0, fn char, acc ->
-      case char_to_index(<<char::utf8>>) do
-        nil ->
-          {:halt, nil}
-
-        i ->
-          {:cont, acc * 57 + i}
-      end
-    end)
-    |> case do
-      nil -> {:error, :invalid_char}
-      value -> {:ok, value}
-    end
+    int_to_string(div(number, 57), [elem(@alphabet_tuple, rem(number, 57)) | acc])
   end
 
   # Pads the given short UUID with the first character of the alphabet until its size reaches 22, 176 bits.
-  # The padding operation uses a tail-recursive helper function for efficiency.
   defp pad_shortuuid(<<_::176>> = shortuuid), do: shortuuid
-  defp pad_shortuuid(shortuuid), do: pad_shortuuid(shortuuid <> <<50>>)
+
+  defp pad_shortuuid(shortuuid),
+    do: pad_shortuuid(<<50>> <> shortuuid)
 
   # Retrieves the index of a given character in the alphabet.
   # This function is generated for each character in the alphabet for quick access.
   @compile {:inline, char_to_index: 1}
-  for {char, i} <- @alphabet_list do
+  for {char, i} <- @codepoint_index do
     defp char_to_index(unquote(char)), do: unquote(i)
   end
 
-  defp char_to_index(_), do: nil
+  defp char_to_index(_), do: raise(ArgumentError)
 end

--- a/test/shortuuid_test.exs
+++ b/test/shortuuid_test.exs
@@ -118,7 +118,7 @@ defmodule ShortUUIDTest do
     end
   end
 
-  describe "decode/1" do
+  describe "decode/2" do
     test "decodes a valid shortuuid" do
       assert {:ok, "2a162ee5-02f4-4701-9e87-72762cbce5e2"} =
                ShortUUID.decode("9VprZJ9U7Tgg2PJ8BfTAek")
@@ -176,9 +176,19 @@ defmodule ShortUUIDTest do
       assert {:error, _} = ShortUUID.decode(true)
       assert {:error, _} = ShortUUID.decode(false)
     end
+
+    test "decodes legacy shortuuid" do
+      assert {:ok, "2a162ee5-02f4-4701-9e87-72762cbce5e2"} =
+               ShortUUID.decode("keATfB8JP2ggT7U9JZrpV9", legacy: true)
+    end
   end
 
-  describe "decode!/1" do
+  describe "decode!/2" do
+    test "decodes legacy shortuuid" do
+      assert "2a162ee5-02f4-4701-9e87-72762cbce5e2" =
+               ShortUUID.decode!("keATfB8JP2ggT7U9JZrpV9", legacy: true)
+    end
+
     test "raises an ArgumentError for and invalid ShortUUID" do
       assert_raise ArgumentError, fn ->
         ShortUUID.decode!("invalid-shortuuid")

--- a/test/shortuuid_test.exs
+++ b/test/shortuuid_test.exs
@@ -8,7 +8,7 @@ defmodule ShortUUIDTest do
   describe "encode/1" do
     test "should pad shorter ints" do
       uuid = "00000001-0001-0001-0001-000000000001"
-      assert {:ok, "UD6ibhr3V4YXvriP822222"} = ShortUUID.encode(uuid)
+      assert {:ok, "222228PirvXY4V3rhbi6DU"} = ShortUUID.encode(uuid)
     end
 
     test "should handle encoding nil UUID" do
@@ -17,39 +17,39 @@ defmodule ShortUUIDTest do
     end
 
     test "should encode regular UUIDs" do
-      assert {:ok, "keATfB8JP2ggT7U9JZrpV9"} =
+      assert {:ok, "9VprZJ9U7Tgg2PJ8BfTAek"} =
                ShortUUID.encode("2a162ee5-02f4-4701-9e87-72762cbce5e2")
 
-      assert "keATfB8JP2ggT7U9JZrpV9" = ShortUUID.encode!("2a162ee5-02f4-4701-9e87-72762cbce5e2")
+      assert "9VprZJ9U7Tgg2PJ8BfTAek" = ShortUUID.encode!("2a162ee5-02f4-4701-9e87-72762cbce5e2")
 
-      assert {:ok, "keATfB8JP2ggT7U9JZrpV9"} =
+      assert {:ok, "9VprZJ9U7Tgg2PJ8BfTAek"} =
                ShortUUID.encode("2a162ee502f447019e8772762cbce5e2")
 
-      assert "keATfB8JP2ggT7U9JZrpV9" = ShortUUID.encode!("2a162ee502f447019e8772762cbce5e2")
+      assert "9VprZJ9U7Tgg2PJ8BfTAek" = ShortUUID.encode!("2a162ee502f447019e8772762cbce5e2")
     end
 
     test "should encode UUIDs in curly braces (MS format)" do
-      assert {:ok, "keATfB8JP2ggT7U9JZrpV9"} =
+      assert {:ok, "9VprZJ9U7Tgg2PJ8BfTAek"} =
                ShortUUID.encode("{2a162ee5-02f4-4701-9e87-72762cbce5e2}")
 
-      assert {:ok, "keATfB8JP2ggT7U9JZrpV9"} =
+      assert {:ok, "9VprZJ9U7Tgg2PJ8BfTAek"} =
                ShortUUID.encode("{2A162EE5-02F4-4701-9E87-72762CBCE5E2}")
 
-      assert {:ok, "keATfB8JP2ggT7U9JZrpV9"} =
+      assert {:ok, "9VprZJ9U7Tgg2PJ8BfTAek"} =
                ShortUUID.encode("{2a162ee502f447019e8772762cbce5e2}")
 
-      assert {:ok, "keATfB8JP2ggT7U9JZrpV9"} =
+      assert {:ok, "9VprZJ9U7Tgg2PJ8BfTAek"} =
                ShortUUID.encode("{2A162EE502F447019E8772762CBCE5E2}")
     end
 
     test "should encode uppercase UUIDs" do
-      assert {:ok, "keATfB8JP2ggT7U9JZrpV9"} =
+      assert {:ok, "9VprZJ9U7Tgg2PJ8BfTAek"} =
                ShortUUID.encode("2A162EE5-02F4-4701-9E87-72762CBCE5E2")
 
-      assert {:ok, "keATfB8JP2ggT7U9JZrpV9"} =
+      assert {:ok, "9VprZJ9U7Tgg2PJ8BfTAek"} =
                ShortUUID.encode("2A162EE502F447019E8772762CBCE5E2")
 
-      assert {:ok, "keATfB8JP2ggT7U9JZrpV9"} =
+      assert {:ok, "9VprZJ9U7Tgg2PJ8BfTAek"} =
                ShortUUID.encode("2a162EE5-02f4-4701-9e87-72762CBCE5e2")
     end
 
@@ -74,18 +74,18 @@ defmodule ShortUUIDTest do
     end
 
     test "encode binary UUIDs" do
-      assert {:ok, "PuQURs6h2XSBBVNgqSHJZn"} =
+      assert {:ok, "nZJHSqgNVBBSX2h6sRUQuP"} =
                ShortUUID.encode(
                  <<250, 98, 175, 128, 168, 97, 69, 108, 171, 119, 213, 103, 126, 46, 139, 168>>
                )
 
-      assert {:ok, "keATfB8JP2ggT7U9JZrpV9"} =
+      assert {:ok, "9VprZJ9U7Tgg2PJ8BfTAek"} =
                ShortUUID.encode(
                  <<0x2A, 0x16, 0x2E, 0xE5, 0x02, 0xF4, 0x47, 0x01, 0x9E, 0x87, 0x72, 0x76, 0x2C,
                    0xBC, 0xE5, 0xE2>>
                )
 
-      assert "keATfB8JP2ggT7U9JZrpV9" =
+      assert "9VprZJ9U7Tgg2PJ8BfTAek" =
                ShortUUID.encode!(
                  <<0x2A, 0x16, 0x2E, 0xE5, 0x02, 0xF4, 0x47, 0x01, 0x9E, 0x87, 0x72, 0x76, 0x2C,
                    0xBC, 0xE5, 0xE2>>
@@ -96,7 +96,7 @@ defmodule ShortUUIDTest do
                ShortUUID.encode(<<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>)
 
       # max
-      assert {:ok, "5B8cwPMGnU6qLbRvo7qEZo"} =
+      assert {:ok, "oZEq7ovRbLq6UnGMPwc8B5"} =
                ShortUUID.encode(
                  <<255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
                    255>>
@@ -121,9 +121,9 @@ defmodule ShortUUIDTest do
   describe "decode/1" do
     test "decodes a valid shortuuid" do
       assert {:ok, "2a162ee5-02f4-4701-9e87-72762cbce5e2"} =
-               ShortUUID.decode("keATfB8JP2ggT7U9JZrpV9")
+               ShortUUID.decode("9VprZJ9U7Tgg2PJ8BfTAek")
 
-      assert "2a162ee5-02f4-4701-9e87-72762cbce5e2" = ShortUUID.decode!("keATfB8JP2ggT7U9JZrpV9")
+      assert "2a162ee5-02f4-4701-9e87-72762cbce5e2" = ShortUUID.decode!("9VprZJ9U7Tgg2PJ8BfTAek")
     end
 
     test "returns an error for an invalid ShortUUID" do
@@ -156,7 +156,7 @@ defmodule ShortUUIDTest do
     end
 
     test "fails when encoded value is > 128 bit" do
-      assert {:error, _} = ShortUUID.decode("6B8cwPMGnU6qLbRvo7qEZo")
+      assert {:error, _} = ShortUUID.decode("oZEq7ovRbLq6UnGMPwc8B6")
     end
 
     test "should not support legacy unpadded strings" do


### PR DESCRIPTION
Similar to implementations in other languages move the most significant bit to the beginning in the encoded string

Fixes https://github.com/gpedic/ex_shortuuid/issues/5